### PR TITLE
Fixing Android Studio CodeSignatureVerifier

### DIFF
--- a/Recipes - Download/AndroidStudio.download.recipe
+++ b/Recipes - Download/AndroidStudio.download.recipe
@@ -44,14 +44,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>expected_authority_names</key>
-				<array>
-					<string>Developer ID Application: Google Inc.</string>
-					<string>Developer ID Certification Authority</string>
-					<string>Apple Root CA</string>
-				</array>
 				<key>input_path</key>
 				<string>%pathname%/*.app</string>
+				<key>requirement</key>
+				<string>identifier "com.google.android.studio" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = EQHXZ8M8AV</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
Previous pkg-style "expected_authority_names" was no longer valid.
Replaced with an app-style "requirement".