### PR TITLE
Update AdobeShockwavePlayer.download.recipe

### DIFF
--- a/Recipes - Download/AdobeShockwavePlayer.download.recipe
+++ b/Recipes - Download/AdobeShockwavePlayer.download.recipe
@@ -33,7 +33,7 @@
 			<dict>
 				<key>expected_authority_names</key>
 				<array>
-					<string>Developer ID Installer: Adobe Systems, Inc. (JQ525L2MZD)</string>
+					<string>Developer ID Installer: Adobe Systems, Inc.</string>
 					<string>Developer ID Certification Authority</string>
 					<string>Apple Root CA</string>
 				</array>


### PR DESCRIPTION
Was getting below when running.  I'm new to CodeSignatureVerifier so hope I'm suggesting right thing.  When I made this change locally the recipe started working again.

CodeSignatureVerifier: Mismatch in authority names
CodeSignatureVerifier: Expected: Developer ID Installer: Adobe Systems, Inc. (JQ525L2MZD) -> Developer ID Certification Authority -> Apple Root CA
CodeSignatureVerifier: Found:    Developer ID Installer: Adobe Systems, Inc. -> Developer ID Certification Authority -> Apple Root CA