### PR TITLE
Change chown dictionary and dir permission

### DIFF
--- a/Recipes - pkg/appleLoops.pkg.recipe
+++ b/Recipes - pkg/appleLoops.pkg.recipe
@@ -68,7 +68,7 @@
 					<key>usr/local/</key>
 					<string>0755</string>
 					<key>usr/local/bin/</key>
-					<string>0775</string>
+					<string>0755</string>
 				</dict>
 				<key>pkgroot</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
@@ -96,9 +96,9 @@
 					<array>
 						<dict>
 							<key>group</key>
-							<string>admin</string>
+							<string>wheel</string>
 							<key>path</key>
-							<string>usr/local/bin</string>
+							<string>usr</string>
 							<key>user</key>
 							<string>root</string>
 						</dict>


### PR DESCRIPTION
The previous chown dictionary left the /usr /usr/local and /usr/local/bin directories with ownership that differ from the original folders, which is root:wheel.  the /usr/local/bin/ directory was also changed to 0775, rather than kept as 0755.