### PR TITLE
Updated Suspicious Package Recipes

### DIFF
--- a/Recipes - Download/SuspiciousPackage.download.recipe
+++ b/Recipes - Download/SuspiciousPackage.download.recipe
@@ -3,8 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest installer for suspicious package. 
-	Verification bit borrowed from com.github.jps3.download.SuspiciousPackageQLP</string>
+	<string>Downloads the latest dmg for Suspicious Package.</string>
 	<key>Identifier</key>
 	<string>com.github.novaksam.download.SuspiciousPackage</string>
 	<key>Input</key>
@@ -12,7 +11,7 @@
 		<key>NAME</key>
 		<string>Suspicious Package</string>
 		<key>pkg_url</key>
-		<string>http://www.mothersruin.com/software/downloads/SuspiciousPackage.xip</string>
+		<string>https://www.mothersruin.com/software/downloads/SuspiciousPackage.dmg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
@@ -26,6 +25,17 @@
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/*.app</string>
+				<key>requirement</key>
+				<string>anchor apple generic and identifier "com.mothersruin.SuspiciousPackageApp" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "936EB786NH")</string>
+			</dict>
 		</dict>
 		<dict>
 			<key>Processor</key>

--- a/Recipes - pkg/SuspiciousPackage.pkg.recipe
+++ b/Recipes - pkg/SuspiciousPackage.pkg.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads latest Suspicious Package installer, unpacks it, and re-labels the installer.</string>
+	<string>Downloads latest Suspicious Package dmg, unpacks it, and creates a pkg.</string>
 	<key>Identifier</key>
 	<string>com.github.novaksam.pkg.SuspiciousPackage</string>
 	<key>Input</key>
@@ -18,122 +18,10 @@
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/Extract</string>
-			</dict>
 			<key>Processor</key>
-			<string>com.github.autopkg.novaksam-recipes.Processors/XarExpander</string>
-		</dict>
-		<dict>
+			<string>AppPkgCreator</string>
 			<key>Arguments</key>
-			<dict>
-				<key>info_path</key>
-				<string>%RECIPE_CACHE_DIR%/Extract/%NAME%.app</string>
-				<key>plist_keys</key>
-				<dict>
-					<key>CFBundleIdentifier</key>
-					<string>bundleid</string>
-					<key>CFBundleShortVersionString</key>
-					<string>version</string>
-				</dict>
-			</dict>
-			<key>Processor</key>
-			<string>PlistReader</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/Extract/%NAME%.app/Contents/Info.plist</string>
-			</dict>
-			<key>Processor</key>
-			<string>com.github.autopkg.novaksam-recipes.Processors/MinimumOSExtractor</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>bundleid</key>
-				<string>%bundleid%</string>
-				<key>pkg_build_name</key>
-				<string>%NAME%-%version%</string>
-				<key>pkg_dir</key>
-				<string>%RECIPE_CACHE_DIR%</string>
-				<key>version</key>
-				<string>%version%</string>
-			</dict>
-			<key>Processor</key>
-			<string>com.github.autopkg.novaksam-recipes.Processors/PkgBuildTester</string>
-			<key>comment</key>
-			<string>Look in our recipe cache for an existing, current package.</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>predicate</key>
-				<string>pkg_build_matches == YES</string>
-			</dict>
-			<key>Processor</key>
-			<string>StopProcessingIf</string>
-			<key>comment</key>
-			<string>If a package has already been built with this version and ID (and "force_pkg_build" is False), we're done.</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkgdirs</key>
-				<dict>
-					<key>Applications</key>
-					<string>0775</string>
-				</dict>
-				<key>pkgroot</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-			</dict>
-			<key>Processor</key>
-			<string>PkgRootCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
-				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/Extract/%NAME%.app</string>
-			</dict>
-			<key>Processor</key>
-			<string>Copier</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_request</key>
-				<dict>
-					<key>chown</key>
-					<array>
-						<dict>
-							<key>group</key>
-							<string>admin</string>
-							<key>path</key>
-							<string>Applications</string>
-							<key>user</key>
-							<string>root</string>
-						</dict>
-					</array>
-					<key>id</key>
-					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
-					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
-					<key>version</key>
-					<string>%version%</string>
-				</dict>
-			</dict>
-			<key>Processor</key>
-			<string>PkgCreator</string>
+			<dict/>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Updated the Suspicious Package download and pkg Recipes.

+ Updated URL
+ Application is distributed in a .dmg now instead of a .xip
+ Added Code Signature Verification
+ Updated packaging processor steps in the pkg recipe

I removed the extra processors in the pkg recipe as most would fail using the AppPkgCreator processor.

The MinimumOSExtractor processor was also only able to determine the the OS requirements as such:  `OS_REQUIREMENTS': '10.11.x,10.12.x`  which I believe isn't what most people would want to set.

Feel free to make any changes if you have different preferences.