### PR TITLE
Update minimum AutoPkg version to 0.5.0

### DIFF
--- a/Recipes - pkg/appleLoops.pkg.recipe
+++ b/Recipes - pkg/appleLoops.pkg.recipe
@@ -16,7 +16,7 @@
         <string>carlashley/appleloops</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.1</string>
+    <string>0.5.0</string>
     <key>Process</key>
     <array>
         <dict>


### PR DESCRIPTION
GitHubReleasesInfoProvider processor requires 0.5.0