### PR TITLE
Basic python3 compatibility

### DIFF
--- a/Processors/AdobeAcrobatDcUpdateInfoProvider.py
+++ b/Processors/AdobeAcrobatDcUpdateInfoProvider.py
@@ -77,7 +77,7 @@ class AdobeAcrobatDcUpdateInfoProvider(Processor):
             url_handle = urlopen(AR_UPDATER_BASE_URL + AR_URL_TEMPLATE % major_version)
             version_string = url_handle.read()
             url_handle.close()
-        except BaseException as err:
+        except Exception as err:
             raise ProcessorError("Can't open URL template: %s" % (err))
         version_string = version_string.replace(AR_MAJREV_IDENTIFIER, major_version)
 

--- a/Processors/AdobeAcrobatDcUpdateInfoProvider.py
+++ b/Processors/AdobeAcrobatDcUpdateInfoProvider.py
@@ -21,9 +21,13 @@
 # pylint: disable=e1101
 
 from __future__ import absolute_import
-import urllib2
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["AdobeAcrobatDcUpdateInfoProvider"]
 
@@ -69,10 +73,8 @@ class AdobeAcrobatDcUpdateInfoProvider(Processor):
     def get_reader_updater_dmg_url(self, major_version):
         '''Returns download URL for Adobe Reader Updater DMG'''
 
-        request = urllib2.Request(
-            AR_UPDATER_BASE_URL + AR_URL_TEMPLATE % major_version)
         try:
-            url_handle = urllib2.urlopen(request)
+            url_handle = urlopen(AR_UPDATER_BASE_URL + AR_URL_TEMPLATE % major_version)
             version_string = url_handle.read()
             url_handle.close()
         except BaseException as err:

--- a/Processors/AdobeAcrobatDcUpdateInfoProvider.py
+++ b/Processors/AdobeAcrobatDcUpdateInfoProvider.py
@@ -20,6 +20,7 @@
 # specific processors.
 # pylint: disable=e1101
 
+from __future__ import absolute_import
 import urllib2
 
 from autopkglib import Processor, ProcessorError

--- a/Processors/AdobeAcrobatReaderDcUpdateInfoProvider.py
+++ b/Processors/AdobeAcrobatReaderDcUpdateInfoProvider.py
@@ -78,7 +78,7 @@ class AdobeAcrobatReaderDcUpdateInfoProvider(Processor):
             url_handle = urlopen(AR_UPDATER_BASE_URL + AR_URL_TEMPLATE % major_version)
             version_string = url_handle.read()
             url_handle.close()
-        except BaseException as err:
+        except Exception as err:
             raise ProcessorError("Can't open URL template: %s" % (err))
         version_string = version_string.replace(AR_MAJREV_IDENTIFIER, major_version)
 

--- a/Processors/AdobeAcrobatReaderDcUpdateInfoProvider.py
+++ b/Processors/AdobeAcrobatReaderDcUpdateInfoProvider.py
@@ -21,9 +21,13 @@
 # pylint: disable=e1101
 
 from __future__ import absolute_import
-import urllib2
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["AdobeAcrobatReaderDcUpdateInfoProvider"]
 
@@ -70,10 +74,8 @@ class AdobeAcrobatReaderDcUpdateInfoProvider(Processor):
     def get_reader_updater_dmg_url(self, major_version):
         '''Returns download URL for Adobe Reader Updater DMG'''
 
-        request = urllib2.Request(
-            AR_UPDATER_BASE_URL + AR_URL_TEMPLATE % major_version)
         try:
-            url_handle = urllib2.urlopen(request)
+            url_handle = urlopen(AR_UPDATER_BASE_URL + AR_URL_TEMPLATE % major_version)
             version_string = url_handle.read()
             url_handle.close()
         except BaseException as err:

--- a/Processors/AdobeAcrobatReaderDcUpdateInfoProvider.py
+++ b/Processors/AdobeAcrobatReaderDcUpdateInfoProvider.py
@@ -20,6 +20,7 @@
 # specific processors.
 # pylint: disable=e1101
 
+from __future__ import absolute_import
 import urllib2
 
 from autopkglib import Processor, ProcessorError

--- a/Processors/CURLRedirectDownloader.py
+++ b/Processors/CURLRedirectDownloader.py
@@ -17,15 +17,18 @@
 """See docstring for URLDownloader class"""
 
 from __future__ import absolute_import
+
 import os.path
 import re
 import subprocess
 import time
+
 # import urllib2
 import xattr
+from autopkglib import Processor, ProcessorError
+
 # import zlib
 
-from autopkglib import Processor, ProcessorError
 
 try:
     from autopkglib import BUNDLE_ID

--- a/Processors/CURLRedirectDownloader.py
+++ b/Processors/CURLRedirectDownloader.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 """See docstring for URLDownloader class"""
 
+from __future__ import absolute_import
 import os.path
 import re
 import subprocess
@@ -134,7 +135,7 @@ class CURLRedirectDownloader(Processor):
         if not os.path.exists(download_dir):
             try:
                 os.makedirs(download_dir)
-            except OSError, err:
+            except OSError as err:
                 raise ProcessorError(
                     "Can't create %s: %s" % (download_dir, err.strerror))
 

--- a/Processors/CURLRedirectDownloader.py
+++ b/Processors/CURLRedirectDownloader.py
@@ -203,7 +203,7 @@ class CURLRedirectDownloader(Processor):
             else:
                 time.sleep(0.1)
 
-            if proc.poll() != None:
+            if proc.poll() is not None:
                 # For small download files curl may exit before all headers
                 # have been parsed, don't immediately exit.
                 maxheaders -= 1
@@ -272,7 +272,7 @@ class CURLRedirectDownloader(Processor):
                 else:
                     time.sleep(0.1)
 
-                if proc2.poll() != None:
+                if proc2.poll() is not None:
                     # For small download files curl may exit before all headers
                     # have been parsed, don't immediately exit.
                     maxheaders2 -= 1

--- a/Processors/DSStoreEraser.py
+++ b/Processors/DSStoreEraser.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import errno
 import shutil

--- a/Processors/DSStoreEraser.py
+++ b/Processors/DSStoreEraser.py
@@ -15,9 +15,6 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import os
-import errno
-import shutil
 import re
 import FoundationPlist
 
@@ -32,27 +29,23 @@ class DSStoreEraser(Processor):
             "description": "Path to where the file you want to modify is"
         }
     }
-    
+
     output_variables = {
     }
-    
+
     __doc__ = description
 
 
-    
-    def main(self):
-	inputfile = open(self.env["file_path"],'r')
-	temp = (re.sub("(.*?)DS_Store","",inputfile.read()))
-	outputfile = open(self.env["file_path"],'w')
-	outputfile.write(temp)
-	inputfile.close()
-	outputfile.close()
 
-        
+    def main(self):
+        inputfile = open(self.env["file_path"], 'r')
+        temp = (re.sub("(.*?)DS_Store", "", inputfile.read()))
+        outputfile = open(self.env["file_path"], 'w')
+        outputfile.write(temp)
+        inputfile.close()
+        outputfile.close()
 
 
 if __name__ == '__main__':
     processor = DSStoreEraser()
     processor.execute_shell()
-    
-

--- a/Processors/DSStoreEraser.py
+++ b/Processors/DSStoreEraser.py
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	  http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/Processors/DSStoreEraser.py
+++ b/Processors/DSStoreEraser.py
@@ -40,7 +40,7 @@ class DSStoreEraser(Processor):
 
     def main(self):
         inputfile = open(self.env["file_path"], 'r')
-        temp = (re.sub("(.*?)DS_Store", "", inputfile.read()))
+        temp = (re.sub(r"(.*?)DS_Store", "", inputfile.read()))
         outputfile = open(self.env["file_path"], 'w')
         outputfile.write(temp)
         inputfile.close()

--- a/Processors/DSStoreEraser.py
+++ b/Processors/DSStoreEraser.py
@@ -15,10 +15,11 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import re
-import FoundationPlist
 
 from autopkglib import Processor, ProcessorError
+
 
 class DSStoreEraser(Processor):
     description = """Given a text file, will read and the and exclude lines containing DS_Store"""

--- a/Processors/FileChmodEditor.py
+++ b/Processors/FileChmodEditor.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import errno
 import shutil

--- a/Processors/FileChmodEditor.py
+++ b/Processors/FileChmodEditor.py
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	  http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -49,22 +49,20 @@ class FileChmodEditor(Processor):
             "description": """Modifier to change to (in 444 format)"""
         }
     }
-    
+
     output_variables = {
     }
-    
+
     __doc__ = description
 
 
-    
+
     def main(self):
-        
+
         os.chmod(self.env["pathname"],int(self.env["modifier"],8))
-        
+
 
 
 if __name__ == '__main__':
     processor = FileChmodEditor()
     processor.execute_shell()
-    
-

--- a/Processors/FileChmodEditor.py
+++ b/Processors/FileChmodEditor.py
@@ -15,11 +15,9 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import os
-import errno
-import shutil
 
-import FoundationPlist
+import errno
+import os
 
 from autopkglib import Processor, ProcessorError
 

--- a/Processors/FlatPkgScriptEditor.py
+++ b/Processors/FlatPkgScriptEditor.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 import os
 import errno
 import shutil
@@ -61,7 +62,7 @@ class FlatPkgScriptEditor(Processor):
     
     def main(self):
         
-        os.chmod(self.env["pathname"],0644)
+        os.chmod(self.env["pathname"],0o644)
         f = open(self.env["pathname"],'r')
         filedata = f.read()
         f.close()
@@ -71,7 +72,7 @@ class FlatPkgScriptEditor(Processor):
         f=open(self.env["pathname"],'w')
         f.write(newdata)
         f.close()
-        os.chmod(self.env["pathname"],0744)
+        os.chmod(self.env["pathname"],0o744)
         
 
 

--- a/Processors/FlatPkgScriptEditor.py
+++ b/Processors/FlatPkgScriptEditor.py
@@ -14,11 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import absolute_import
-import os
-import errno
-import shutil
 
-import FoundationPlist
+import errno
+import os
 
 from autopkglib import Processor, ProcessorError
 

--- a/Processors/FlatPkgScriptEditor.py
+++ b/Processors/FlatPkgScriptEditor.py
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	  http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -52,32 +52,30 @@ class FlatPkgScriptEditor(Processor):
             "description": """The text to replace the found text with"""
         }
     }
-    
+
     output_variables = {
     }
-    
+
     __doc__ = description
 
 
-    
+
     def main(self):
-        
+
         os.chmod(self.env["pathname"],0o644)
         f = open(self.env["pathname"],'r')
         filedata = f.read()
         f.close()
-        
+
         newdata = filedata.replace(self.env["text_to_replace"],self.env["replacement_text"])
-        
+
         f=open(self.env["pathname"],'w')
         f.write(newdata)
         f.close()
         os.chmod(self.env["pathname"],0o744)
-        
+
 
 
 if __name__ == '__main__':
     processor = FlatPkgScriptEditor()
     processor.execute_shell()
-    
-

--- a/Processors/MASReceipt.py
+++ b/Processors/MASReceipt.py
@@ -4,9 +4,11 @@
 #
 
 from __future__ import absolute_import
+
 import os
 
 from autopkglib import Processor, ProcessorError
+
 
 class MASReceipt(Processor):
     description = "Will either delete the _MASReceipt folder or replace it with a dummy receipt."

--- a/Processors/MASReceipt.py
+++ b/Processors/MASReceipt.py
@@ -10,7 +10,7 @@ from autopkglib import Processor, ProcessorError
 
 class MASReceipt(Processor):
     description = "Will either delete the _MASReceipt folder or replace it with a dummy receipt."
-    
+
     input_variables = {
         "mas_action": {
             "required": True,
@@ -25,31 +25,31 @@ class MASReceipt(Processor):
             "description": "Text content written into the dummy receipt file. Default is 'dummy receipt' but you can change this if you want to leave messages."
         },
     }
-    
+
     output_variables = {
     }
-    
+
     __doc__ = description
-    
+
     def main(self):
         app_path =os.path.expanduser(self.env["app_path"])
         mas_action = self.env["mas_action"]
         dummy_receipt_content = self.env.get("dummy_receipt_content", "dummy receipt")
-        
+
         if os.path.basename(app_path).endswith('.app'):
             masreceipt_dir_path = os.path.join(app_path, "Contents", "_MASReceipt")
         elif os.path.basename(app_path) == "_MASReceipt":
             masreceipt_dir_path = app_path
         else:
             raise ProcessorError("Not an app or MASReceipt folder: %s" % (pathname))
-        
+
         masreceipt_file_path = os.path.join(masreceipt_dir_path, "receipt")
-        
+
         if mas_action in ("dummy", "delete"):
             if os.path.exists(masreceipt_dir_path):
                 if os.path.exists(masreceipt_file_path):
                     os.remove(masreceipt_file_path)
-            
+
             if mas_action == "dummy":
                 self.output('Replacing %s with dummy.' % (masreceipt_file_path))
                 try:
@@ -59,11 +59,10 @@ class MASReceipt(Processor):
                     f.close()
             elif mas_action == "delete":
                 if os.path.exists(masreceipt_dir_path):
-	                self.output('Deleting %s' % (masreceipt_dir_path))
-	                os.rmdir(masreceipt_dir_path)
-        
+                    self.output('Deleting %s' % (masreceipt_dir_path))
+                    os.rmdir(masreceipt_dir_path)
+
 
 if __name__ == '__main__':
     processor = MASReceipt()
     processor.execute_shell()
-    

--- a/Processors/MASReceipt.py
+++ b/Processors/MASReceipt.py
@@ -3,6 +3,7 @@
 # Copyright 2014 Armin Briegel
 #
 
+from __future__ import absolute_import
 import os
 
 from autopkglib import Processor, ProcessorError

--- a/Processors/MinimumOSExtractor.py
+++ b/Processors/MinimumOSExtractor.py
@@ -127,11 +127,11 @@ class MinimumOSExtractor(DmgMounter):
                     # Create the list of all the OS's between the min and max
                     # It's ok if minimum_os_version contains 3 numbers, since
                     # we only use the second one to create our range
-                    # print minimum_os_version
+                    # print(minimum_os_version)
                     os_min = int(minimum_os_version.split('.')[1])
                     # You have to add one to the maximum OS version, because the range
                     # appears to start at the minimum, but end one short of the max
-                    # print maximum_os_version
+                    # print(maximum_os_version)
                     os_max = int(maximum_os_version.split('.')[1]) + 1
                     os_requirement = ''
                     for os_version in range(os_min, os_max):

--- a/Processors/MinimumOSExtractor.py
+++ b/Processors/MinimumOSExtractor.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 """See docstring for MinimumOSExtractor class"""
 
+from __future__ import absolute_import
 import os.path
 
 from autopkglib import Processor, ProcessorError
@@ -154,7 +155,7 @@ class MinimumOSExtractor(DmgMounter):
                 self.output("Maximum OS Version requirements %s in file %s"
                             % (self.env['OS_MAXIMUM'], input_plist_path))
 
-            except FoundationPlist.FoundationPlistException, err:
+            except FoundationPlist.FoundationPlistException as err:
                 raise ProcessorError(err)
 
         finally:

--- a/Processors/MinimumOSExtractor.py
+++ b/Processors/MinimumOSExtractor.py
@@ -109,7 +109,7 @@ class MinimumOSExtractor(DmgMounter):
                 # Set the Maximum OS, if default
                 # https://stackoverflow.com/a/1777365
                 maximum_os_version = str(self.env['maximum_os_version'])
-                if maximum_os_version is 'HOST_OS':
+                if maximum_os_version == 'HOST_OS':
                     # https://stackoverflow.com/a/1777365
                     v, _, _ = platform.mac_ver()
                     maximum_os_version = str('.'.join(v.split('.')[:2]))
@@ -136,7 +136,7 @@ class MinimumOSExtractor(DmgMounter):
                     os_max = int(maximum_os_version.split('.')[1]) + 1
                     os_requirement = ''
                     for os_version in range(os_min, os_max):
-                        if os_requirement is '':
+                        if os_requirement == '':
                             os_requirement = '10.' + str(os_version) + '.x'
                         else:
                             os_requirement = os_requirement + ',10.' + str(os_version) + '.x'

--- a/Processors/MinimumOSExtractor.py
+++ b/Processors/MinimumOSExtractor.py
@@ -18,12 +18,13 @@
 """See docstring for MinimumOSExtractor class"""
 
 from __future__ import absolute_import
-import os.path
 
+import os.path
+import platform
+
+import FoundationPlist
 from autopkglib import Processor, ProcessorError
 from autopkglib.DmgMounter import DmgMounter
-import FoundationPlist
-import platform
 
 __all__ = ["MinimumOSExtractor"]
 

--- a/Processors/PackageInfoReader.py
+++ b/Processors/PackageInfoReader.py
@@ -18,6 +18,7 @@
 """See docstring for MinimumOSExtractor class"""
 
 from __future__ import absolute_import
+
 import os.path
 import xml.etree.ElementTree as ET
 

--- a/Processors/PackageInfoReader.py
+++ b/Processors/PackageInfoReader.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 """See docstring for MinimumOSExtractor class"""
 
+from __future__ import absolute_import
 import os.path
 import xml.etree.ElementTree as ET
 
@@ -66,7 +67,7 @@ class PackageInfoReader(Processor):
             self.env["pkginfo_version"] = str(pkginfo_version)
             self.env["bundleid"] = str(bundleid)
 
-        except FoundationPlist.FoundationPlistException, err:
+        except FoundationPlist.FoundationPlistException as err:
             raise ProcessorError(err)
 
 

--- a/Processors/PathListCopier.py
+++ b/Processors/PathListCopier.py
@@ -4,12 +4,12 @@
 #
 
 from __future__ import absolute_import
-import os
+
 import errno
+import os
 import shutil
 
 import FoundationPlist
-
 from autopkglib import Processor, ProcessorError
 
 

--- a/Processors/PathListCopier.py
+++ b/Processors/PathListCopier.py
@@ -38,14 +38,14 @@ class PathListCopier(Processor):
         "check_version_path": {
             "required": False,
             "description": """This processor will attempt to determine the vesion at the
-                    local path and pathname. If the version at pathname is the same, then 
-                    it will not copy. Otherwise the data at pathname will be overwritten. 
-                    If this path is not given, the first item from sourcelist will be 
+                    local path and pathname. If the version at pathname is the same, then
+                    it will not copy. Otherwise the data at pathname will be overwritten.
+                    If this path is not given, the first item from sourcelist will be
                     used."""
         },
         "plist_version_key": {
             "required": False,
-            "description": """Key to use on the Info.plist to read the version. Default 
+            "description": """Key to use on the Info.plist to read the version. Default
             is CFBundleShortVersionString."""
         },
         "sourcelist": {
@@ -53,61 +53,61 @@ class PathListCopier(Processor):
             "description": "Array of paths that will be copied to pathname."
         }
     }
-    
+
     output_variables = {
         "version": {
             "description": "The version determined by the process."
         },
         "download_changed": {
-            "description": """Boolean indicating if files where actually copied. Using 
+            "description": """Boolean indicating if files where actually copied. Using
                 this terminology so that Processors down the path treat it the same way
                  as URLDownloader."""
         },
         "pathname": {
-        	"description": """pathname the files were copied to"""
+            "description": """pathname the files were copied to"""
         }
     }
-    
+
     __doc__ = description
 
     def get_version(self, filepath):
         if os.path.exists(filepath):
             #try to determine the version
-        
+
             version_basename = os.path.basename(filepath)
-                    
+
             # is it an app bundle?
             if version_basename.endswith(".app"):
                 filepath = os.path.join(filepath, "Contents", "Info.plist")
         else:
             self.output("Cannot determine version. %s does not exist." % (filepath))
             return None
-                
+
         try:
             plist = FoundationPlist.readPlist(filepath)
             version_key = self.env.get("plist_version_key", "CFBundleShortVersionString")
             version = plist.get(version_key, None)
             self.output("Found version %s in file %s" % (version, filepath))
-        
+
         except FoundationPlist.FoundationPlistException as err:
-            raise ProcessorError(err) 
-    
-        return version  
+            raise ProcessorError(err)
+
+        return version
 
 
-    
+
     def main(self):
-        
+
         pathname =os.path.expanduser(self.env["pathname"])
         makedir_p(pathname)
-        
+
         check_version_path = self.env.get("check_version_path", self.env["sourcelist"][0])
-        
+
         source_version = self.get_version(check_version_path)
-        
+
         target_version_path = os.path.join(pathname, os.path.relpath(check_version_path, "/"))
         target_version = self.get_version(target_version_path)
-        
+
         self.env["version"] = source_version
 
         # if version is equal, don't copy, write message, stop
@@ -117,18 +117,18 @@ class PathListCopier(Processor):
         else:
             self.env["download_changed"] = True
             self.env["pathname"] = pathname
-            
+
             # clean out pathname folder
             shutil.rmtree(pathname)
-            
+
             # copy all files from path list
             for source_item in self.env["sourcelist"]:
                 #copy all the things
                 dest_item = os.path.join(pathname, os.path.relpath(source_item, "/"))
                 self.output("Copying: %s" % (source_item))
-                
+
                 makedir_p(os.path.dirname(dest_item))
-                
+
                 try:
                     if os.path.isdir(source_item):
                         shutil.copytree(source_item, dest_item, symlinks=True)
@@ -145,5 +145,3 @@ class PathListCopier(Processor):
 if __name__ == '__main__':
     processor = PathListCopier()
     processor.execute_shell()
-    
-

--- a/Processors/PathListCopier.py
+++ b/Processors/PathListCopier.py
@@ -137,7 +137,7 @@ class PathListCopier(Processor):
                     else:
                         shutil.copy(source_item, dest_item)
                     self.output("Copied %s to %s" % (source_item, dest_item))
-                except BaseException as err:
+                except Exception as err:
                     raise ProcessorError("Can't copy %s to %s: %s" % (source_item, dest_item, err))
 
 

--- a/Processors/PathListCopier.py
+++ b/Processors/PathListCopier.py
@@ -3,6 +3,7 @@
 # Copyright 2014 Armin Briegel
 #
 
+from __future__ import absolute_import
 import os
 import errno
 import shutil
@@ -88,7 +89,7 @@ class PathListCopier(Processor):
             version = plist.get(version_key, None)
             self.output("Found version %s in file %s" % (version, filepath))
         
-        except FoundationPlist.FoundationPlistException, err:
+        except FoundationPlist.FoundationPlistException as err:
             raise ProcessorError(err) 
     
         return version  
@@ -136,7 +137,7 @@ class PathListCopier(Processor):
                     else:
                         shutil.copy(source_item, dest_item)
                     self.output("Copied %s to %s" % (source_item, dest_item))
-                except BaseException, err:
+                except BaseException as err:
                     raise ProcessorError("Can't copy %s to %s: %s" % (source_item, dest_item, err))
 
 

--- a/Processors/PkgBuildTester.py
+++ b/Processors/PkgBuildTester.py
@@ -16,6 +16,7 @@
 """Look in the build directory for a pre-existing package."""
 
 
+from __future__ import absolute_import
 import os.path
 import subprocess
 import xml.etree.ElementTree as ET

--- a/Processors/PkgBuildTester.py
+++ b/Processors/PkgBuildTester.py
@@ -17,12 +17,12 @@
 
 
 from __future__ import absolute_import
+
 import os.path
 import subprocess
 import xml.etree.ElementTree as ET
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["PkgBuildTester"]
 
@@ -128,4 +128,3 @@ class PkgBuildTester(Processor):
 if __name__ == '__main__':
     PROCESSOR = PkgBuildTester()
     PROCESSOR.execute_shell()
-

--- a/Processors/ResourceForkCopier.py
+++ b/Processors/ResourceForkCopier.py
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	  http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/Processors/ResourceForkCopier.py
+++ b/Processors/ResourceForkCopier.py
@@ -14,14 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+
 import os.path
-import errno
 import traceback
 
 import xattr
-import FoundationPlist
 from autopkglib import Processor, ProcessorError
 from autopkglib.DmgMounter import DmgMounter
 

--- a/Processors/ResourceForkCopier.py
+++ b/Processors/ResourceForkCopier.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os.path
 import errno
 import traceback
@@ -62,7 +64,7 @@ class ResourceForkCopier(DmgMounter):
                 self.output("Resource Fork copied")
         except:
             var = traceback.format_exc()
-            print ("ERROR:", var)
+            print(("ERROR:", var))
             self.output("Resoruce Fork error: " + var)
         finally:
             if dmg:

--- a/Processors/XarExpander.py
+++ b/Processors/XarExpander.py
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#	  http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/Processors/XarExpander.py
+++ b/Processors/XarExpander.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 import os.path
 import subprocess
 import xml.etree.ElementTree as ET

--- a/Processors/XarExpander.py
+++ b/Processors/XarExpander.py
@@ -16,9 +16,9 @@
 
 
 from __future__ import absolute_import
+
 import os.path
 import subprocess
-import xml.etree.ElementTree as ET
 
 from autopkglib import Processor, ProcessorError
 

--- a/validate_recipes_novaksam.py
+++ b/validate_recipes_novaksam.py
@@ -30,6 +30,8 @@ optional arguments:
 """
 
 
+from __future__ import absolute_import
+from __future__ import print_function
 import argparse
 import os
 import subprocess
@@ -135,13 +137,13 @@ class Results(object):
                 if verbose or not result[0]:
                     self._print_result(result)
         else:
-            print "Ok."
+            print("Ok.")
 
     def report_all(self):
         self.report(verbose=True)
 
     def _print_result(self, line):
-        print "Test: %s Result: %s" % (line[1], line[0])
+        print("Test: %s Result: %s" % (line[1], line[0]))
 
 
 def get_argument_parser():
@@ -212,13 +214,13 @@ def validate_recipe(recipe_path, verbose=False):
 
     header = "Testing recipe: %s" % recipe_path
     print_bar(len(header))
-    print header
+    print(header)
     print_bar(len(header))
 
     if os.path.exists(recipe_path):
         recipe = get_recipe(recipe_path)
     else:
-        print "File not found."
+        print("File not found.")
         sys.exit(1)
 
     results = Results()
@@ -886,7 +888,7 @@ def test_lint(recipe):
 
 def print_bar(length=79):
     """Print a line of '-'s."""
-    print length * "-"
+    print(length * "-")
 
 
 def main():

--- a/validate_recipes_novaksam.py
+++ b/validate_recipes_novaksam.py
@@ -30,18 +30,21 @@ optional arguments:
 """
 
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+
 import argparse
 import os
 import subprocess
 import sys
 
 # pylint: disable=no-name-in-module
-from Foundation import (NSData,
-                        NSPropertyListSerialization,
-                        NSPropertyListMutableContainersAndLeaves,
-                        NSPropertyListXMLFormat_v1_0)
+from Foundation import (
+    NSData,
+    NSPropertyListMutableContainersAndLeaves,
+    NSPropertyListSerialization,
+    NSPropertyListXMLFormat_v1_0,
+)
+
 # pylint: enable=no-name-in-module
 
 


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.