### PR TITLE
Update Brackets download recipe

### DIFF
--- a/Recipes - Download/Brackets.download.recipe
+++ b/Recipes - Download/Brackets.download.recipe
@@ -8,14 +8,8 @@
 	<string>com.github.novaksam.download.Brackets</string>
 	<key>Input</key>
 	<dict>
-		<key>DOWNLOAD_PATTERN</key>
-		<string>(/adobe/brackets/releases/download/release-\d+\.\d+/.+\.dmg)</string>
 		<key>NAME</key>
 		<string>Brackets</string>
-		<key>VERSION_PATTERN</key>
-		<string>(/adobe/brackets/releases/tag/release-\d+\.\d+(?="))</string>
-		<key>VERSION_URL</key>
-		<string>https://github.com/adobe/brackets/releases.atom</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
@@ -24,32 +18,30 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>re_pattern</key>
-				<string>%VERSION_PATTERN%</string>
-				<key>url</key>
-				<string>%VERSION_URL%</string>
+				<key>asset_regex</key>
+				<string>Brackets\.Release\.[\d\.]+\.dmg</string>
+				<key>github_repo</key>
+				<string>adobe/brackets</string>
 			</dict>
 			<key>Processor</key>
-			<string>URLTextSearcher</string>
+			<string>GitHubReleasesInfoProvider</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>re_pattern</key>
-				<string>%DOWNLOAD_PATTERN%</string>
-				<key>url</key>
-				<string>https://github.com%match%</string>
+				<key>index</key>
+				<integer>1</integer>
+				<key>split_on</key>
+				<string>-</string>
 			</dict>
 			<key>Processor</key>
-			<string>URLTextSearcher</string>
+			<string>com.github.homebysix.VersionSplitter/VersionSplitter</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%.dmg</string>
-				<key>url</key>
-				<string>https://github.com%match%</string>
+				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -58,7 +50,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/*.app</string>
+				<string>%pathname%/Brackets.app</string>
 				<key>requirement</key>
 				<string>identifier "io.brackets.appshell" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = JQ525L2MZD</string>
 			</dict>


### PR DESCRIPTION
- Switch to GitHubReleasesInfoProvider for getting latest release
- Split version `release-x.xx` to just `x.xx`
- Hard code path to app for code signature verification