### PR TITLE
Update Acrobat/Reader info providers with URLGetter

### DIFF
--- a/Processors/AdobeAcrobatDcUpdateInfoProvider.py
+++ b/Processors/AdobeAcrobatDcUpdateInfoProvider.py
@@ -2,7 +2,7 @@
 #
 # Copyright 2014: wycomco GmbH (choules@wycomco.de)
 #           2015: modifications by Tim Sutton
-#			2015: modifications by Sam Novak
+# 			2015: modifications by Sam Novak
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,19 +15,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""See docstring for AdobeReaderURLProvider class"""
+"""See docstring for AdobeAcrobatDcUpdateInfoProvider class"""
 # Disabling warnings for env members and imports that only affect recipe-
 # specific processors.
 # pylint: disable=e1101
 
 from __future__ import absolute_import
 
-from autopkglib import Processor, ProcessorError
-
-try:
-    from urllib.parse import urlopen  # For Python 3
-except ImportError:
-    from urllib2 import urlopen  # For Python 2
+from autopkglib import Processor, ProcessorError, URLGetter
 
 __all__ = ["AdobeAcrobatDcUpdateInfoProvider"]
 
@@ -35,8 +30,8 @@ MAJOR_VERSION_DEFAULT = "AcrobatDC"
 CHECK_OS_VERSION_DEFAULT = "10.8"
 
 AR_UPDATER_DOWNLOAD_URL = (
-    "https://download.adobe.com/"
-    "pub/adobe/acrobat/mac/%s/%s/%sUpd%s.dmg")
+    "https://download.adobe.com/pub/adobe/acrobat/mac/%s/%s/%sUpd%s.dmg"
+)
 
 AR_UPDATER_BASE_URL = "https://armmf.adobe.com/arm-manifests/mac"
 AR_URL_TEMPLATE = "/%s/acrobat/current_version.txt"
@@ -45,44 +40,49 @@ OSX_MAJREV_IDENTIFIER = "{OS_VER_MAJ}"
 OSX_MINREV_IDENTIFIER = "{OS_VER_MIN}"
 
 
-class AdobeAcrobatDcUpdateInfoProvider(Processor):
+class AdobeAcrobatDcUpdateInfoProvider(URLGetter):
     """Provides URL to the latest Adobe Reader release."""
+
     description = __doc__
     input_variables = {
         "major_version": {
             "required": False,
-            "description": ("Major version. Examples: 'AcrobatDC', 'Acrobat2015'. Defaults to "
-                            "%s" % MAJOR_VERSION_DEFAULT)
+            "description": (
+                "Major version. Examples: 'AcrobatDC', 'Acrobat2015'. Defaults to "
+                "%s" % MAJOR_VERSION_DEFAULT
+            ),
         },
         "os_version": {
             "required": False,
             "default": CHECK_OS_VERSION_DEFAULT,
-            "description": ("Version of OS X to check. Default: %s" %
-                            CHECK_OS_VERSION_DEFAULT)
-        }
+            "description": (
+                "Version of OS X to check. Default: %s" % CHECK_OS_VERSION_DEFAULT
+            ),
+        },
     }
     output_variables = {
-        "url": {
-            "description": "URL to the latest Adobe Reader release.",
-        },
-        "version": {
-            "description": "Version for this update.",
-        },
+        "url": {"description": "URL to the latest Adobe Reader release.",},
+        "version": {"description": "Version for this update.",},
     }
 
     def get_reader_updater_dmg_url(self, major_version):
-        '''Returns download URL for Adobe Reader Updater DMG'''
+        """Returns download URL for Adobe Reader Updater DMG"""
 
         try:
-            url_handle = urlopen(AR_UPDATER_BASE_URL + AR_URL_TEMPLATE % major_version)
-            version_string = url_handle.read()
-            url_handle.close()
+            version_string = self.download(
+                AR_UPDATER_BASE_URL + AR_URL_TEMPLATE % major_version, text=True
+            )
         except Exception as err:
             raise ProcessorError("Can't open URL template: %s" % (err))
         version_string = version_string.replace(AR_MAJREV_IDENTIFIER, major_version)
 
-        versioncode = version_string.replace('.', '')
-        url = AR_UPDATER_DOWNLOAD_URL % (major_version, versioncode, major_version, versioncode)
+        versioncode = version_string.replace(".", "")
+        url = AR_UPDATER_DOWNLOAD_URL % (
+            major_version,
+            versioncode,
+            major_version,
+            versioncode,
+        )
 
         return (url, version_string)
 

--- a/Processors/AdobeAcrobatReaderDcUpdateInfoProvider.py
+++ b/Processors/AdobeAcrobatReaderDcUpdateInfoProvider.py
@@ -2,7 +2,7 @@
 #
 # Copyright 2014: wycomco GmbH (choules@wycomco.de)
 #           2015: modifications by Tim Sutton
-#			2015: modifications by Sam Novak
+# 			2015: modifications by Sam Novak
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,19 +15,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""See docstring for AdobeReaderURLProvider class"""
+"""See docstring for AdobeAcrobatReaderDcUpdateInfoProvider class"""
 # Disabling warnings for env members and imports that only affect recipe-
 # specific processors.
 # pylint: disable=e1101
 
 from __future__ import absolute_import
 
-from autopkglib import Processor, ProcessorError
-
-try:
-    from urllib.parse import urlopen  # For Python 3
-except ImportError:
-    from urllib2 import urlopen  # For Python 2
+from autopkglib import Processor, ProcessorError, URLGetter
 
 __all__ = ["AdobeAcrobatReaderDcUpdateInfoProvider"]
 
@@ -36,8 +31,8 @@ CHECK_OS_VERSION_DEFAULT = "10.8"
 MAJOR_VERSION_MATCH_STR = "adobe/reader/mac/%s"
 
 AR_UPDATER_DOWNLOAD_URL = (
-    "https://download.adobe.com/"
-    "pub/adobe/reader/mac/%s/%s/%sUpd%s_MUI.dmg")
+    "https://download.adobe.com/pub/adobe/reader/mac/%s/%s/%sUpd%s_MUI.dmg"
+)
 # AcroRdrDCUpd1501620045_MUI.dmg
 AR_UPDATER_BASE_URL = "https://armmf.adobe.com/arm-manifests/mac"
 AR_URL_TEMPLATE = "/%s/reader/current_version.txt"
@@ -46,45 +41,50 @@ OSX_MAJREV_IDENTIFIER = "{OS_VER_MAJ}"
 OSX_MINREV_IDENTIFIER = "{OS_VER_MIN}"
 
 
-class AdobeAcrobatReaderDcUpdateInfoProvider(Processor):
+class AdobeAcrobatReaderDcUpdateInfoProvider(URLGetter):
     """Provides URL to the latest Adobe Reader release."""
+
     description = __doc__
     input_variables = {
         "major_version": {
             "required": False,
-            "description": ("Major version. Examples: 'AcrobatDC', 'Acrobat2015'. Defaults to "
-                            "%s" % MAJOR_VERSION_DEFAULT)
+            "description": (
+                "Major version. Examples: 'AcrobatDC', 'Acrobat2015'. Defaults to "
+                "%s" % MAJOR_VERSION_DEFAULT
+            ),
         },
         "os_version": {
             "required": False,
             "default": CHECK_OS_VERSION_DEFAULT,
-            "description": ("Version of OS X to check. Default: %s" %
-                            CHECK_OS_VERSION_DEFAULT)
-        }
+            "description": (
+                "Version of OS X to check. Default: %s" % CHECK_OS_VERSION_DEFAULT
+            ),
+        },
     }
     output_variables = {
-        "url": {
-            "description": "URL to the latest Adobe Reader release.",
-        },
-        "version": {
-            "description": "Version for this update.",
-        },
+        "url": {"description": "URL to the latest Adobe Reader release.",},
+        "version": {"description": "Version for this update.",},
     }
 
     def get_reader_updater_dmg_url(self, major_version):
-        '''Returns download URL for Adobe Reader Updater DMG'''
+        """Returns download URL for Adobe Reader Updater DMG"""
 
         try:
-            url_handle = urlopen(AR_UPDATER_BASE_URL + AR_URL_TEMPLATE % major_version)
-            version_string = url_handle.read()
-            url_handle.close()
+            version_string = self.download(
+                AR_UPDATER_BASE_URL + AR_URL_TEMPLATE % major_version, text=True
+            )
         except Exception as err:
             raise ProcessorError("Can't open URL template: %s" % (err))
         version_string = version_string.replace(AR_MAJREV_IDENTIFIER, major_version)
 
-        versioncode = version_string.replace('.', '')
+        versioncode = version_string.replace(".", "")
         readerversion = "AcroRdrDC"
-        url = AR_UPDATER_DOWNLOAD_URL % (major_version, versioncode, readerversion, versioncode)
+        url = AR_UPDATER_DOWNLOAD_URL % (
+            major_version,
+            versioncode,
+            readerversion,
+            versioncode,
+        )
 
         return (url, version_string)
 


### PR DESCRIPTION
AdobeAcrobatReaderDcUpdateInfoProvider output:
```
com.github.autopkg.novaksam-recipes.Processors/AdobeAcrobatReaderDcUpdateInfoProvider
{'Input': {'major_version': 'AcrobatDC', 'os_version': '10.9.0'}}
AdobeAcrobatReaderDcUpdateInfoProvider: Found URL https://download.adobe.com/pub/adobe/reader/mac/AcrobatDC/1902120061/AcroRdrDCUpd1902120061_MUI.dmg
{'Output': {'url': 'https://download.adobe.com/pub/adobe/reader/mac/AcrobatDC/1902120061/AcroRdrDCUpd1902120061_MUI.dmg',
            'version': '19.021.20061'}}
```

AdobeAcrobatDcUpdateInfoProvider output:
```
com.github.autopkg.novaksam-recipes.Processors/AdobeAcrobatDcUpdateInfoProvider
{'Input': {'major_version': 'AcrobatDC', 'os_version': '10.9.0'}}
AdobeAcrobatDcUpdateInfoProvider: Found URL https://download.adobe.com/pub/adobe/acrobat/mac/AcrobatDC/1902120061/AcrobatDCUpd1902120061.dmg
{'Output': {'url': 'https://download.adobe.com/pub/adobe/acrobat/mac/AcrobatDC/1902120061/AcrobatDCUpd1902120061.dmg',
            'version': '19.021.20061'}}
```