### PR TITLE
Update search URL for Android Studio

### DIFF
--- a/Recipes - Download/AndroidStudio.download.recipe
+++ b/Recipes - Download/AndroidStudio.download.recipe
@@ -13,7 +13,7 @@
 		<key>SEARCH_PATTERN</key>
 		<string>(https\://redirector\.gvt1\.com/edgedl/android/studio/install/.+/android-studio-ide.+\.dmg)</string>
 		<key>SEARCH_URL</key>
-		<string>https://developer.android.com/sdk/index.html</string>
+		<string>https://developer.android.com/studio</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>


### PR DESCRIPTION
Currently errors on trying to read the old URL:
```
Processing AndroidStudio.munki.recipe...
No match found on URL: https://developer.android.com/sdk/index.html
Failed.
```