### PR TITLE
Adapt URL in AdobeAcrobat URL Providers

### DIFF
--- a/Processors/AdobeAcrobatDcUpdateInfoProvider.py
+++ b/Processors/AdobeAcrobatDcUpdateInfoProvider.py
@@ -30,7 +30,7 @@ MAJOR_VERSION_DEFAULT = "AcrobatDC"
 CHECK_OS_VERSION_DEFAULT = "10.8"
 
 AR_UPDATER_DOWNLOAD_URL = (
-    "https://download.adobe.com/pub/adobe/acrobat/mac/%s/%s/%sUpd%s.dmg"
+    "https://ardownload2.adobe.com/pub/adobe/acrobat/mac/%s/%s/%sUpd%s.dmg"
 )
 
 AR_UPDATER_BASE_URL = "https://armmf.adobe.com/arm-manifests/mac"

--- a/Processors/AdobeAcrobatReaderDcUpdateInfoProvider.py
+++ b/Processors/AdobeAcrobatReaderDcUpdateInfoProvider.py
@@ -31,7 +31,7 @@ CHECK_OS_VERSION_DEFAULT = "10.8"
 MAJOR_VERSION_MATCH_STR = "adobe/reader/mac/%s"
 
 AR_UPDATER_DOWNLOAD_URL = (
-    "https://download.adobe.com/pub/adobe/reader/mac/%s/%s/%sUpd%s_MUI.dmg"
+    "https://ardownload2.adobe.com/pub/adobe/reader/mac/%s/%s/%sUpd%s_MUI.dmg"
 )
 # AcroRdrDCUpd1501620045_MUI.dmg
 AR_UPDATER_BASE_URL = "https://armmf.adobe.com/arm-manifests/mac"


### PR DESCRIPTION
Adobe changed their URLs for downloading the Acrobat updates to https://ardownload2.adobe.com/
The version info Urls work just fine and the way the urls are designed stay the same. 
I tested the new URL with the following recipes: 
* `AdobeAcrobatDCUpdates.download.recipe `
* `AdobeAcrobatReaderDCUpdates.download.recipe `