### PR TITLE
Removing duplicate CodeSignatureVerifier step in Android Studio

### DIFF
--- a/Recipes - pkg/AndroidStudio.pkg.recipe
+++ b/Recipes - pkg/AndroidStudio.pkg.recipe
@@ -29,17 +29,6 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>input_path</key>
-				<string>%pathname%/%app_name%</string>
-				<key>requirement</key>
-				<string>identifier "com.google.android.studio" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = EQHXZ8M8AV</string>
-			</dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>input_plist_path</key>
 				<string>%pathname%/%app_name%/Contents/Info.plist</string>
 			</dict>


### PR DESCRIPTION
CodeSignatureVerifier is ran in both the .download and .pkg recipes.

Removing the second run from the .pkg recipe.