### PR TITLE
Deprecate Nvidia CUDA recipes

### DIFF
--- a/Recipes - Download/NvidiaCudaDriver.download.recipe
+++ b/Recipes - Download/NvidiaCudaDriver.download.recipe
@@ -22,6 +22,19 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>warning_message</key>
+				<string>Nvidia CUDA 10.2 (toolkit and driver) was the last release to support macOS. Details:
+	- https://docs.nvidia.com/cuda/archive/10.2/cuda-toolkit-release-notes/index.html#title-new-features
+	- https://mjtsai.com/blog/2019/11/25/nvidia-drops-cuda-support-for-macos/
+	- https://gizmodo.com/apple-and-nvidia-are-over-1840015246
+				</string>
+			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>re_pattern</key>
 				<string>%SEARCH_PATTERN%</string>
 				<key>url</key>

--- a/Recipes - Download/NvidiaCudaToolkit.download.recipe
+++ b/Recipes - Download/NvidiaCudaToolkit.download.recipe
@@ -22,6 +22,19 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>warning_message</key>
+				<string>Nvidia CUDA 10.2 (toolkit and driver) was the last release to support macOS. Details:
+	- https://docs.nvidia.com/cuda/archive/10.2/cuda-toolkit-release-notes/index.html#title-new-features
+	- https://mjtsai.com/blog/2019/11/25/nvidia-drops-cuda-support-for-macos/
+	- https://gizmodo.com/apple-and-nvidia-are-over-1840015246
+				</string>
+			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>re_pattern</key>
 				<string>%SEARCH_PATTERN%</string>
 				<key>url</key>


### PR DESCRIPTION
Nvidia CUDA 10.2 (toolkit and driver) was the last release to support macOS. Details:

- https://docs.nvidia.com/cuda/archive/10.2/cuda-toolkit-release-notes/index.html#title-new-features
- https://mjtsai.com/blog/2019/11/25/nvidia-drops-cuda-support-for-macos/
- https://gizmodo.com/apple-and-nvidia-are-over-1840015246

Related: https://github.com/autopkg/jessepeterson-recipes/pull/96, https://github.com/autopkg/jps3-recipes/pull/91