### PR TITLE
Change parent recipe for cgerke-recipes deprecation

### DIFF
--- a/Google Drive/Google Drive.jss.recipe
+++ b/Google Drive/Google Drive.jss.recipe
@@ -30,7 +30,7 @@
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.autopkg.cgerke-recipes.pkg.GoogleDrive</string>
+	<string>com.github.homebysix.pkg.GoogleDrive</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Wireshark/Wireshark.jss.recipe
+++ b/Wireshark/Wireshark.jss.recipe
@@ -30,7 +30,7 @@
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.autopkg.cgerke-recipes.pkg.Wireshark</string>
+	<string>com.github.homebysix.pkg.Wireshark</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
The parent recipe has been copied to homebysix-recipes in order to prepare for cgerke-recipes deprecation. For details, see: autopkg/cgerke-recipes#37

