### PR TITLE
Resolving improper permissions on Info.plist

### DIFF
--- a/Recipes - pkg/AndroidStudio.pkg.recipe
+++ b/Recipes - pkg/AndroidStudio.pkg.recipe
@@ -18,31 +18,88 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>PkgRootCreator</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pkgdirs</key>
+				<dict/>
+				<key>pkgroot</key>
+				<string>%RECIPE_CACHE_DIR%/pkgroot</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>AppDmgVersioner</string>
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_path</key>
 				<string>%pathname%</string>
 			</dict>
-			<key>Processor</key>
-			<string>AppDmgVersioner</string>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>Copier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>source_path</key>
+				<string>%pathname%/%app_name%</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/pkgroot/Applications/%app_name%</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>com.github.autopkg.novaksam-recipes.Processors/MinimumOSExtractor</string>
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
 				<string>%pathname%/%app_name%/Contents/Info.plist</string>
 			</dict>
-			<key>Processor</key>
-			<string>com.github.autopkg.novaksam-recipes.Processors/MinimumOSExtractor</string>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>PkgCreator</string>
 			<key>Arguments</key>
 			<dict>
-				<key>app_path</key>
-				<string>%pathname%/%app_name%</string>
+				<key>pkg_request</key>
+				<dict>
+					<key>chown</key>
+					<array>
+						<dict>
+							<key>path</key>
+							<string>/Applications/%app_name%/Contents/Info.plist</string>
+							<key>user</key>
+							<string>root</string>
+							<key>group</key>
+							<string>wheel</string>
+							<key>mode</key>
+							<string>0644</string>
+						</dict>
+					</array>
+					<key>id</key>
+					<string>%bundleid%</string>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
+					<key>pkgroot</key>
+					<string>%RECIPE_CACHE_DIR%/pkgroot</string>
+					<key>pkgtype</key>
+					<string>flat</string>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
 			</dict>
+		</dict>
+		<dict>
 			<key>Processor</key>
-			<string>AppPkgCreator</string>
+			<string>PathDeleter</string>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/pkgroot</string>
+				</array>
+			</dict>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Improper permissions (`-rw------`) are set on `Android Studio.app/Contents/Info.plist` from Google, when they should be `-rw-r--r--`.
This prevented the opening of the application.

Updated the processors to set the proper permissions on the .app.