### PR TITLE
Fixed returned version variable name

### DIFF
--- a/Processors/AdobeAcrobatDcUpdateInfoProvider.py
+++ b/Processors/AdobeAcrobatDcUpdateInfoProvider.py
@@ -80,7 +80,7 @@ class AdobeAcrobatDcUpdateInfoProvider(URLGetter):
 
         versioncode = version_string.replace(".", "")
         versioncode = versioncode.replace("\n","")
-    
+
         url = AR_UPDATER_DOWNLOAD_URL % (
             major_version,
             versioncode,
@@ -88,7 +88,7 @@ class AdobeAcrobatDcUpdateInfoProvider(URLGetter):
             versioncode,
         )
 
-        return (url, version_string)
+        return (url, versioncode)
 
     def main(self):
         major_version = self.env.get("major_version", MAJOR_VERSION_DEFAULT)

--- a/Processors/AdobeAcrobatReaderDcUpdateInfoProvider.py
+++ b/Processors/AdobeAcrobatReaderDcUpdateInfoProvider.py
@@ -80,6 +80,8 @@ class AdobeAcrobatReaderDcUpdateInfoProvider(URLGetter):
         version_string = version_string.replace(AR_MAJREV_IDENTIFIER, major_version)
 
         versioncode = version_string.replace(".", "")
+        versioncode = versioncode.replace("\n","")
+
         readerversion = "AcroRdrDC"
         url = AR_UPDATER_DOWNLOAD_URL % (
             major_version,
@@ -88,7 +90,7 @@ class AdobeAcrobatReaderDcUpdateInfoProvider(URLGetter):
             versioncode,
         )
 
-        return (url, version_string)
+        return (url, versioncode)
 
     def main(self):
         major_version = self.env.get("major_version", MAJOR_VERSION_DEFAULT)


### PR DESCRIPTION
The previous `version_string` variable was being returned not the current `versioncode` which removed the spurious newlines.