### PR TITLE
Update Brackets download Recipe

### DIFF
--- a/Recipes - Download/Brackets.download.recipe
+++ b/Recipes - Download/Brackets.download.recipe
@@ -19,7 +19,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>asset_regex</key>
-				<string>Brackets\.[\d\.]+\.signed\.dmg</string>
+				<string>[Bb]rackets\.[\d\.]+\.dmg</string>
 				<key>github_repo</key>
 				<string>brackets-cont/brackets</string>
 			</dict>


### PR DESCRIPTION
Name of Brackets release dmg is now lowercase, and no longer contains .signed.

- Remove \.signed Filter
- Filter for upper or lowercase in asset_regex