### PR TITLE
Adoptium JDK

### DIFF
--- a/Recipes - Download/AdoptiumJDK11Intel.download.recipe
+++ b/Recipes - Download/AdoptiumJDK11Intel.download.recipe
@@ -3,18 +3,26 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest Android Studio IDE from Google.</string>
+	<string>Downloads the latest Adoptium JDK version 11.</string>
 	<key>Identifier</key>
-	<string>com.github.novaksam.download.AndroidStudio</string>
+	<string>com.github.novaksam.download.AdoptiumJDK11Intel</string>
 	<key>Input</key>
-	<dict>
-		<key>NAME</key>
-		<string>AndroidStudio</string>
-		<key>SEARCH_PATTERN</key>
-		<string>(https\://redirector\.gvt1\.com/edgedl/android/studio/install/.+/android-studio.+\.dmg)</string>
-		<key>SEARCH_URL</key>
-		<string>https://developer.android.com/studio</string>
-	</dict>
+	    <dict>
+        	<key>NAME</key>
+        	<string>Adoptium JDK 11</string>
+        	<key>VENDOR</key>
+        	<string>Adoptium</string>
+        	<key>DISTRIBUTION</key>
+        	<string>OpenJDK</string>
+        	<key>SOFTWARETITLE</key>
+        	<string>Java</string>
+        	<key>SOFTWARETYPE</key>
+        	<string>JDK</string>
+        	<key>SEARCH_URL</key>
+        	<string>https://github.com/adoptium/temurin11-binaries/releases/latest</string>
+        	<key>SEARCH_PATTERN</key>
+        	<string>(https.*?OpenJDK11U-jdk.*?\.pkg)</string>
+    	</dict>
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>Process</key>

--- a/Recipes - Download/AdoptiumJDK17Intel.download.recipe
+++ b/Recipes - Download/AdoptiumJDK17Intel.download.recipe
@@ -3,18 +3,26 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest Android Studio IDE from Google.</string>
+	<string>Downloads the latest Adoptium JDK version 17.</string>
 	<key>Identifier</key>
-	<string>com.github.novaksam.download.AndroidStudio</string>
+	<string>com.github.novaksam.download.AdoptiumJDK17Intel</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
-		<string>AndroidStudio</string>
-		<key>SEARCH_PATTERN</key>
-		<string>(https\://redirector\.gvt1\.com/edgedl/android/studio/install/.+/android-studio.+\.dmg)</string>
+		<string>Adoptium JDK 17</string>
+		<key>VENDOR</key>
+		<string>Adoptium</string>
+		<key>DISTRIBUTION</key>
+		<string>OpenJDK</string>
+		<key>SOFTWARETITLE</key>
+		<string>Java</string>
+		<key>SOFTWARETYPE</key>
+		<string>JDK</string>
 		<key>SEARCH_URL</key>
-		<string>https://developer.android.com/studio</string>
-	</dict>
+		<string>https://github.com/adoptium/temurin17-binaries/releases/latest</string>
+		<key>SEARCH_PATTERN</key>
+		<string>(https.*?OpenJDK17U-jdk.*?\.pkg)</string>
+    	</dict>
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>Process</key>

--- a/Recipes - Download/AdoptiumJDK8Intel.download.recipe
+++ b/Recipes - Download/AdoptiumJDK8Intel.download.recipe
@@ -3,13 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest Android Studio IDE from Google.</string>
+	<string>Downloads the latest Adoptium JDK version 8.</string>
 	<key>Identifier</key>
 	<string>com.github.novaksam.download.AdoptiumJDK8Intel</string>
 	<key>Input</key>
 	    <dict>
         	<key>NAME</key>
-        	<string>Adoptium JDK 11</string>
+        	<string>Adoptium JDK 8</string>
         	<key>VENDOR</key>
         	<string>Adoptium</string>
         	<key>DISTRIBUTION</key>


### PR DESCRIPTION
This does not fix the recipes to make them functional, but does correct the duplicate identifiers to prevent failures of the Android Studio recipe.

Addresses #93 .