### PR TITLE
Recon is no longer distributed as part of the Jamf Pro apps

### DIFF
--- a/Recipes - pkg/JamfPro.pkg.recipe
+++ b/Recipes - pkg/JamfPro.pkg.recipe
@@ -53,17 +53,6 @@
 			<string>CodeSignatureVerifier</string>
 		</dict>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%/Recon.app</string>
-				<key>requirement</key>
-				<string>anchor apple generic and identifier "com.jamfsoftware.Recon" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "483DWKW443"</string>
-			</dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
-		</dict>
-		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>


### PR DESCRIPTION
I had created this previously, but then deleted my fork in a cleanup action before it was merged.