### PR TITLE
Adobe Acrobat/Reader - Set the real version string to %version%

### DIFF
--- a/Processors/AdobeAcrobatDcUpdateInfoProvider.py
+++ b/Processors/AdobeAcrobatDcUpdateInfoProvider.py
@@ -65,6 +65,9 @@ class AdobeAcrobatDcUpdateInfoProvider(URLGetter):
     output_variables = {
         "url": {"description": "URL to the latest Adobe Reader release.",},
         "version": {"description": "Version for this update.",},
+        "versioncode": {
+            "description": "Version string without decimails (e.g. '.')."
+        }
     }
 
     def get_reader_updater_dmg_url(self, major_version):

--- a/Processors/AdobeAcrobatDcUpdateInfoProvider.py
+++ b/Processors/AdobeAcrobatDcUpdateInfoProvider.py
@@ -78,8 +78,8 @@ class AdobeAcrobatDcUpdateInfoProvider(URLGetter):
             raise ProcessorError("Can't open URL template: %s" % (err))
         version_string = version_string.replace(AR_MAJREV_IDENTIFIER, major_version)
 
+        version_string = version_string.replace("\n","")
         versioncode = version_string.replace(".", "")
-        versioncode = versioncode.replace("\n","")
 
         url = AR_UPDATER_DOWNLOAD_URL % (
             major_version,

--- a/Processors/AdobeAcrobatDcUpdateInfoProvider.py
+++ b/Processors/AdobeAcrobatDcUpdateInfoProvider.py
@@ -88,15 +88,16 @@ class AdobeAcrobatDcUpdateInfoProvider(URLGetter):
             versioncode,
         )
 
-        return (url, versioncode)
+        return (url, versioncode, version_string)
 
     def main(self):
         major_version = self.env.get("major_version", MAJOR_VERSION_DEFAULT)
 
-        (url, version) = self.get_reader_updater_dmg_url(major_version)
+        (url, versioncode, version_string) = self.get_reader_updater_dmg_url(major_version)
 
         self.env["url"] = url
-        self.env["version"] = version
+        self.env["version"] = version_string
+        self.env["versioncode"] = versioncode
 
         self.output("Found URL %s" % self.env["url"])
 

--- a/Processors/AdobeAcrobatReaderDcUpdateInfoProvider.py
+++ b/Processors/AdobeAcrobatReaderDcUpdateInfoProvider.py
@@ -66,6 +66,9 @@ class AdobeAcrobatReaderDcUpdateInfoProvider(URLGetter):
     output_variables = {
         "url": {"description": "URL to the latest Adobe Reader release.",},
         "version": {"description": "Version for this update.",},
+        "versioncode": {
+            "description": "Version string without decimails (e.g. '.')."
+        }
     }
 
     def get_reader_updater_dmg_url(self, major_version):

--- a/Processors/AdobeAcrobatReaderDcUpdateInfoProvider.py
+++ b/Processors/AdobeAcrobatReaderDcUpdateInfoProvider.py
@@ -79,8 +79,8 @@ class AdobeAcrobatReaderDcUpdateInfoProvider(URLGetter):
             raise ProcessorError("Can't open URL template: %s" % (err))
         version_string = version_string.replace(AR_MAJREV_IDENTIFIER, major_version)
 
+        version_string = version_string.replace("\n","")
         versioncode = version_string.replace(".", "")
-        versioncode = versioncode.replace("\n","")
 
         readerversion = "AcroRdrDC"
         url = AR_UPDATER_DOWNLOAD_URL % (

--- a/Processors/AdobeAcrobatReaderDcUpdateInfoProvider.py
+++ b/Processors/AdobeAcrobatReaderDcUpdateInfoProvider.py
@@ -90,15 +90,16 @@ class AdobeAcrobatReaderDcUpdateInfoProvider(URLGetter):
             versioncode,
         )
 
-        return (url, versioncode)
+        return (url, versioncode, version_string)
 
     def main(self):
         major_version = self.env.get("major_version", MAJOR_VERSION_DEFAULT)
 
-        (url, version) = self.get_reader_updater_dmg_url(major_version)
+        (url, versioncode, version_string) = self.get_reader_updater_dmg_url(major_version)
 
         self.env["url"] = url
-        self.env["version"] = version
+        self.env["version"] = version_string
+        self.env["versioncode"] = versioncode
 
         self.output("Found URL %s" % self.env["url"])
 


### PR DESCRIPTION
In commit 64d46f3, PR #78, the value used for the AutoPkg `%version%` variable was changed.  This resulted in the `%version%` variable having a value similar to `2300620320` instead of the normally expected `23.006.20320` version string.  Which results in a package name of `Adobe Acrobat DC-2300620320.pkg`.

This PR reverts this to the commonly expected version string format so that the created package also results in the commonly expected name format.

That said, in case someone _**wants**_ a version string in the format of `2300620320`, I have made that available via the variable `%versioncode%`.