### PR TITLE
Fix for Brackets app bundle versioning

### DIFF
--- a/Recipes - pkg/Brackets.pkg.recipe
+++ b/Recipes - pkg/Brackets.pkg.recipe
@@ -18,20 +18,6 @@
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_path</key>
-				<string>%pathname%</string>
-			</dict>
-			<key>Processor</key>
-			<string>AppDmgVersioner</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>app_path</key>
-				<string>%pathname%/%app_name%</string>
-			</dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>
 		</dict>

--- a/Recipes - pkg/Brackets.pkg.recipe
+++ b/Recipes - pkg/Brackets.pkg.recipe
@@ -12,7 +12,7 @@
 		<string>Brackets</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.0</string>
+	<string>1.0.0</string>
 	<key>ParentRecipe</key>
 	<string>com.github.novaksam.download.Brackets</string>
 	<key>Process</key>

--- a/Recipes - pkg/Brackets.pkg.recipe
+++ b/Recipes - pkg/Brackets.pkg.recipe
@@ -3,7 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads latest Brackets disk image and builds a package.</string>
+	<string>Downloads latest Brackets disk image and builds a package.
+	Relies on the Github version string rather than the Info.plist within the app bundle.
+	The application version is not reliably maintained by developer.</string>
 	<key>Identifier</key>
 	<string>com.github.novaksam.pkg.Brackets</string>
 	<key>Input</key>


### PR DESCRIPTION
Since Brackets was taken over / forked from Adobe it appears the the new repository maintainers/developers have been publishing new versions of the app but are not updating the CFBundleShortVersionString inside the Info.plist. The current value for CFBundleShortVersionString is 1.14.2 even though the current published version of the app on Github is 2.2.0 (not including Windows only release). The Brackets download recipe pulls down the correct version but the pkg recipe is relying on the Info.plist when building a pkg file. By removing the AppDmgVersioner processor and leaving just a simple AppPkgCreator on its own the correct version string from Github will be used for both the package receipts and the pkg file name.

I have tested this recipe in my own workflow and can confirm that I'm now getting a newly packaged version with the correct file name and package receipts created (see screenshot below from Suspicious Package). Unfortunately the app still has the wrong value set for the version string but this can't be fixed without breaking the signature. There is a recent issue logged against the Brackets Github repo for this version mismatch and it sounds like they are looking to fix this issue but the changes I have made to this recipe will still continue to work even if the version number issue is resolved by the developers.

![Screenshot 2023-09-26 at 1 50 09 PM](https://github.com/autopkg/novaksam-recipes/assets/1995536/ff5b27fd-957a-4771-b034-fa0797fcb5d9)
