### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Recipes - Download/OpenOffice.download.recipe
+++ b/Recipes - Download/OpenOffice.download.recipe
@@ -23,7 +23,7 @@
 				<key>re_pattern</key>
 				<string>http://sourceforge.net/projects/openofficeorg.mirror/files/(?P&lt;version&gt;[0-9\.]+)</string>
 				<key>url</key>
-				<string>http://sourceforge.net/projects/openofficeorg.mirror/rss?limit=1</string>
+				<string>https://sourceforge.net/projects/openofficeorg.mirror/rss?limit=1</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [in January 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso).

Thanks for considering!