### PR TITLE
Adjust parent for VSCode jamf recipe

### DIFF
--- a/Visual Studio Code/VisualStudioCode.jamf.recipe
+++ b/Visual Studio Code/VisualStudioCode.jamf.recipe
@@ -40,7 +40,7 @@
 	<key>MinimumVersion</key>
 	<string>2.3</string>
 	<key>ParentRecipe</key>
-	<string>com.github.killahquam.pkg.visualstudioscode</string>
+	<string>com.github.amsysuk-recipes.pkg.VisualStudioCode</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
The recipes in killahquam-recipes have been deprecated and will be removed soon. (See https://github.com/autopkg/killahquam-recipes/issues/28 for details.)

This pull request adjusts the parent for a recipe that references killahquam-recipes. The parent has been changed to an actively maintained recipe in another repo.