### PR TITLE
Fix PracticaMusica.download recipe for new zipped app download format

### DIFF
--- a/Recipes - Download/PracticaMusica.download.recipe
+++ b/Recipes - Download/PracticaMusica.download.recipe
@@ -35,6 +35,21 @@
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Practica Musica.app</string>
+				<key>requirement</key>
+				<string>anchor apple generic and identifier "com.ars-nova.practicamusica" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7WU8WLBXK3")</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/Recipes - Download/PracticaMusica.download.recipe
+++ b/Recipes - Download/PracticaMusica.download.recipe
@@ -22,6 +22,11 @@
 			<dict>
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
+				<key>request_headers</key>
+				<dict>
+					<key>User-Agent</key>
+					<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36</string>
+				</dict>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Recipes - Download/PracticaMusica.download.recipe
+++ b/Recipes - Download/PracticaMusica.download.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_URL</key>
-		<string>https://www.ars-nova.com/public/installpractica6site.dmg</string>
+		<string>https://www.ars-nova.com/public/practicamusica7site.zip</string>
 		<key>NAME</key>
 		<string>Practica Musica</string>
 	</dict>


### PR DESCRIPTION
This PR adjusts the Practica Musica download pattern for version 7, which is provided as a zipped app.

It is likely that changes will be needed in the pkg recipe as well, but I don't have a licensed copy of Practica Musica to test that recipe with, so this PR only includes changes to the download recipe.

Verbose recipe run output:

```
% autopkg run -vvq 'Recipes - Download/PracticaMusica.download.recipe'
Processing Recipes - Download/PracticaMusica.download.recipe...
WARNING: Recipes - Download/PracticaMusica.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'request_headers': {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/537.36 (KHTML, like '
                                             'Gecko) Chrome/91.0.4472.114 '
                                             'Safari/537.36'},
           'url': 'https://www.ars-nova.com/public/practicamusica7site.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 25 Nov 2024 22:07:10 GMT
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.novaksam.download.PracticaMusica/downloads/practicamusica7site.zip
{'Output': {'download_changed': True,
            'last_modified': 'Mon, 25 Nov 2024 22:07:10 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.novaksam.download.PracticaMusica/downloads/practicamusica7site.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.novaksam.download.PracticaMusica/downloads/practicamusica7site.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename practicamusica7site.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.novaksam.download.PracticaMusica/downloads/practicamusica7site.zip to ~/Library/AutoPkg/Cache/com.github.novaksam.download.PracticaMusica/Practica Musica
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.novaksam.download.PracticaMusica/Practica '
                         'Musica/Practica Musica.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.ars-nova.practicamusica" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "7WU8WLBXK3")'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.novaksam.download.PracticaMusica/Practica Musica/Practica Musica.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.novaksam.download.PracticaMusica/Practica Musica/Practica Musica.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.novaksam.download.PracticaMusica/Practica Musica/Practica Musica.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.novaksam.download.PracticaMusica/receipts/PracticaMusica.download-receipt-20241227-133941.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.novaksam.download.PracticaMusica/downloads/practicamusica7site.zip
```
