### PR TITLE
Deprecate OpenOffice recipes

### DIFF
--- a/Recipes - Download/OpenOffice.download.recipe
+++ b/Recipes - Download/OpenOffice.download.recipe
@@ -18,6 +18,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the OpenOffice recipes in the hjuutilainen-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>


### PR DESCRIPTION
This PR deprecates the non-functional OpenOffice recipes in this repo, and points users to their working equivalents in the hjuutilainen-recipes repo.
