### PR TITLE
Deprecate TechSmith Relay recipes

### DIFF
--- a/Recipes - Download/TechsmithRelay.download.recipe
+++ b/Recipes - Download/TechsmithRelay.download.recipe
@@ -17,6 +17,10 @@
 	<string>0.4.0</string>
 	<key>Process</key>
 	<array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
The TechSmith Relay recipes in this repo are not working because `example.com` is part of the download URL. It's likely this URL is meant to be overridden by AutoPkg users, however I'm unable to find evidence online that TechSmith Relay is still a product available for download.

This PR deprecates the TechSmith Relay recipes.
