### PR TITLE
Update Jamovi.download.recipe

### DIFF
--- a/Jamovi/Jamovi.download.recipe
+++ b/Jamovi/Jamovi.download.recipe
@@ -42,7 +42,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>(dl.jamovi.org/.*%version%.*-%ARCH%.dmg)</string>
+				<string>(/downloads/.*%version%.*-%ARCH%.dmg)</string>
 				<key>url</key>
 				<string>https://www.jamovi.org/download.html</string>
 				<key>result_output_var_name</key>
@@ -57,7 +57,7 @@
                 		<key>prefetch_filename</key>
                 		<string>True</string>
 				<key>url</key>
-				<string>https://%url%</string>
+				<string>https://www.jamovi.org%url%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Fix search patterns for download URL and resulting prefetch_filename (back to what they were in Commit 191d5df)