### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/Recipes - pkg/AdobeRUM.pkg.recipe
+++ b/Recipes - pkg/AdobeRUM.pkg.recipe
@@ -88,8 +88,6 @@
                     </array>
                     <key>id</key>
                     <string>%IDENTIFIER%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/Recipes - pkg/CasperSuite.pkg.recipe
+++ b/Recipes - pkg/CasperSuite.pkg.recipe
@@ -160,8 +160,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Recipes - pkg/EndNoteX7.pkg.recipe
+++ b/Recipes - pkg/EndNoteX7.pkg.recipe
@@ -139,8 +139,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>scripts</key>

--- a/Recipes - pkg/GarageBand.pkg.recipe
+++ b/Recipes - pkg/GarageBand.pkg.recipe
@@ -89,8 +89,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Recipes - pkg/JamfPro.pkg.recipe
+++ b/Recipes - pkg/JamfPro.pkg.recipe
@@ -99,8 +99,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Recipes - pkg/NvidiaCudaToolkit.pkg.recipe
+++ b/Recipes - pkg/NvidiaCudaToolkit.pkg.recipe
@@ -199,8 +199,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>scripts</key>

--- a/Recipes - pkg/OneDrive.pkg.recipe
+++ b/Recipes - pkg/OneDrive.pkg.recipe
@@ -84,8 +84,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Recipes - pkg/OpenOffice.pkg.recipe
+++ b/Recipes - pkg/OpenOffice.pkg.recipe
@@ -69,8 +69,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>version</key>

--- a/Recipes - pkg/PracticaMusica.pkg.recipe
+++ b/Recipes - pkg/PracticaMusica.pkg.recipe
@@ -159,8 +159,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Recipes - pkg/SoundslidesPlus.pkg.recipe
+++ b/Recipes - pkg/SoundslidesPlus.pkg.recipe
@@ -135,8 +135,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Recipes - pkg/TechsmithRelay.pkg.recipe
+++ b/Recipes - pkg/TechsmithRelay.pkg.recipe
@@ -104,8 +104,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Recipes - pkg/appleLoops.pkg.recipe
+++ b/Recipes - pkg/appleLoops.pkg.recipe
@@ -98,8 +98,6 @@
                     </array>
                     <key>id</key>
                     <string>com.github.carlashley.appleloops</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>pkgname</key>
                     <string>%NAME%-%version%</string>
                     <key>pkgroot</key>

--- a/Recipes - pkg/appleLoopsMandatory.pkg.recipe
+++ b/Recipes - pkg/appleLoopsMandatory.pkg.recipe
@@ -125,8 +125,6 @@
 					</array>
 					<key>id</key>
 					<string>com.github.carlashley.%NAME%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>scripts</key>

--- a/Recipes - pkg/appleLoopsOptional.pkg.recipe
+++ b/Recipes - pkg/appleLoopsOptional.pkg.recipe
@@ -125,8 +125,6 @@
 					</array>
 					<key>id</key>
 					<string>com.github.carlashley.%NAME%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>scripts</key>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._